### PR TITLE
make things easier

### DIFF
--- a/metasploit.sh
+++ b/metasploit.sh
@@ -62,7 +62,7 @@ rm -rf $HOME/metasploit-framework
 echo
 center "*** Downloading..."
 cd $HOME
-git clone https://github.com/rapid7/metasploit-framework.git
+git clone https://github.com/rapid7/metasploit-framework.git --depth=1
 
 echo
 center "*** Installation..."
@@ -77,7 +77,7 @@ gem install nokogiri -v 1.8.0 -- --use-system-libraries
 gem install actionpack
 bundle update activesupport
 bundle update --bundler
-bundle install -j5
+bundle install -j$(nproc --all)
 $PREFIX/bin/find -type f -executable -exec termux-fix-shebang \{\} \;
 rm ./modules/auxiliary/gather/http_pdf_authors.rb
 if [ -e $PREFIX/bin/msfconsole ];then


### PR DESCRIPTION
use --depth=1 to download ~50mb instead of ~500mb and use all CPU cores instead of 5 for bundle install