### PR TITLE
Fix Ruby, Nokogiri, Bundler, and SQLite3 Issues

### DIFF
--- a/.github/workflows/termux-metasploit-arm64.yml
+++ b/.github/workflows/termux-metasploit-arm64.yml
@@ -32,9 +32,8 @@ jobs:
 
           # Domains your installer typically needs
           domains=(
-            packages.termux.dev
+            gnlug.org
             raw.githubusercontent.com
-            packages-cf.termux.dev
             termux.dev
             github.com
             rubygems.org
@@ -59,7 +58,7 @@ jobs:
           cat "$HOSTS"
 
           # Fail early if we couldn't resolve critical domains on the host
-          critical=(packages.termux.dev raw.githubusercontent.com github.com rubygems.org)
+          critical=(gnlug.org raw.githubusercontent.com github.com rubygems.org)
           for c in "${critical[@]}"; do
             if ! grep -q " $c$" "$HOSTS"; then
               echo "ERROR: Could not resolve critical domain: $c"
@@ -94,8 +93,8 @@ jobs:
           id=$(docker ps -q -f name=termux)
           docker exec -u system "$id" bash -lc '
             set -eux
-            # Use primary Termux mirror (bypasses pkg mirror selection)
-            echo "deb https://packages.termux.dev/apt/termux-main stable main" > /data/data/com.termux/files/usr/etc/apt/sources.list
+            # Use GNLUG Termux mirror (bypasses pkg mirror selection)
+            echo "deb https://gnlug.org/pub/termux/termux-main stable main" > /data/data/com.termux/files/usr/etc/apt/sources.list
             apt update -y
             DEBIAN_FRONTEND=noninteractive apt install -y curl git libssh2 -o Dpkg::Options::="--force-confnew"
           '

--- a/.github/workflows/termux-metasploit-arm64.yml
+++ b/.github/workflows/termux-metasploit-arm64.yml
@@ -32,8 +32,9 @@ jobs:
 
           # Domains your installer typically needs
           domains=(
-            gnlug.org
+            packages.termux.dev
             raw.githubusercontent.com
+            packages-cf.termux.dev
             termux.dev
             github.com
             rubygems.org
@@ -58,7 +59,7 @@ jobs:
           cat "$HOSTS"
 
           # Fail early if we couldn't resolve critical domains on the host
-          critical=(gnlug.org raw.githubusercontent.com github.com rubygems.org)
+          critical=(packages.termux.dev raw.githubusercontent.com github.com rubygems.org)
           for c in "${critical[@]}"; do
             if ! grep -q " $c$" "$HOSTS"; then
               echo "ERROR: Could not resolve critical domain: $c"
@@ -93,8 +94,8 @@ jobs:
           id=$(docker ps -q -f name=termux)
           docker exec -u system "$id" bash -lc '
             set -eux
-            # Use GNLUG Termux mirror (bypasses pkg mirror selection)
-            echo "deb https://gnlug.org/pub/termux/termux-main stable main" > /data/data/com.termux/files/usr/etc/apt/sources.list
+            # Use primary Termux mirror (bypasses pkg mirror selection)
+            echo "deb https://packages.termux.dev/apt/termux-main stable main" > /data/data/com.termux/files/usr/etc/apt/sources.list
             apt update -y
             DEBIAN_FRONTEND=noninteractive apt install -y curl git libssh2 -o Dpkg::Options::="--force-confnew"
           '

--- a/README.md
+++ b/README.md
@@ -4,32 +4,22 @@
 ![Metasploit 6 running](https://i.imgur.com/yLFQhvP.png)
 
 ## How to Install
-## Before
+### Before
 
-In order to have updated Termux:
-- **Purge all data** of Termux in Android Settings
-- Uninstall and reinstall latest Termux version from [F-Droid](https://f-droid.org/en/packages/com.termux/) (Version on Play Store is outdated)
-- Then launch Termux to initialization, close it (force stop, not swap)
-- Reopen and follow the instructions below
+1. Install latest Termux version from [F-Droid](https://f-droid.org/en/packages/com.termux). (The version on Play Store is outdated.)
+2. Launch Termux to initialize.
+3. Type `exit` and enter to close it.
+4. Reopen and follow the instructions below.
 
-### Auto
+### Install
 ```bash
-source <(curl -fsSL https://kutt.it/msf)
-```
-
-### Manual
-```bash
-pkg install wget
-
-wget https://github.com/gushmazuko/metasploit_in_termux/raw/master/metasploit.sh
-
-
+pkg install wget -y
+wget https://raw.githubusercontent.com/gushmazuko/metasploit_in_termux/refs/heads/master/metasploit.sh
 chmod +x metasploit.sh
-
 ./metasploit.sh
 ```
 
-## Launch metasploit
+### Launch metasploit
 After installation start Metasploit using the command:
 ```bash
 msfconsole

--- a/metasploit.sh
+++ b/metasploit.sh
@@ -82,6 +82,16 @@ gem install nokogiri -v $NOKOGIRI_VERSION -- --with-cflags="-Wno-implicit-functi
 BUNDLER_VERSION="$(sed -n '/BUNDLED WITH/{n;s/^ *//;p}' Gemfile.lock)"
 gem install bundler -v "${BUNDLER_VERSION}"
 
+# Fix sqlite3 error
+SQLITE3_VERSION=$(cat Gemfile.lock | grep -i sqlite3 | sed 's/sqlite3 [\(\)]/(/g' | cut -d ' ' -f 5 | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?')
+git clone https://github.com/sparklemotion/sqlite3-ruby.git
+cd sqlite3-ruby
+git checkout "v${SQLITE3_VERSION}"
+gem build sqlite3.gemspec
+gem install "sqlite3-${SQLITE3_VERSION}.gem" -- --enable-system-libraries
+cd ..
+bundle config set path.system true
+
 gem install actionpack
 bundle update activesupport
 bundle update --bundler

--- a/metasploit.sh
+++ b/metasploit.sh
@@ -37,7 +37,7 @@ source <(echo "c3Bpbm5lcj0oICd8JyAnLycgJy0nICdcJyApOwoKY291bnQoKXsKICBzcGluICYKI
 # Dependencies Installation
 center "* Dependencies installation..."
 # Skip mirror selection if sources.list is already configured (for CI)
-if ! grep -q "gnlug.org" /data/data/com.termux/files/usr/etc/apt/sources.list 2>/dev/null; then
+if ! grep -q "packages.termux.dev" /data/data/com.termux/files/usr/etc/apt/sources.list 2>/dev/null; then
   pkg update -y
 else
   apt update -y

--- a/metasploit.sh
+++ b/metasploit.sh
@@ -26,6 +26,7 @@ center() {
   printf '%*.*s %s %*.*s\n' 0 "$(((termwidth-2-${#1})/2))" "$padding" "$1" 0 "$(((termwidth-1-${#1})/2))" "$padding"
 }
 
+cd ~
 clear
 center_banner
 

--- a/metasploit.sh
+++ b/metasploit.sh
@@ -102,6 +102,11 @@ center "* Fixing ActionView version compatibility..."
 # Disable the version check entirely since ActionView 8.x might not need the monkey patch
 sed -i 's/raise unless ActionView::VERSION::STRING == .*$/# Version check disabled for ARM64 compatibility/' config/application.rb
 
+# termux-fix-shebang
+termux-fix-shebang ${PREFIX}/opt/metasploit-framework/msfconsole
+termux-fix-shebang ${PREFIX}/opt/metasploit-framework/msfvenom
+termux-fix-shebang ${PREFIX}/opt/metasploit-framework/msfrpcd
+
 # Link Metasploit Executables
 ln -sf ${PREFIX}/opt/metasploit-framework/msfconsole ${PREFIX}/bin/
 ln -sf ${PREFIX}/opt/metasploit-framework/msfvenom ${PREFIX}/bin/

--- a/metasploit.sh
+++ b/metasploit.sh
@@ -36,7 +36,7 @@ source <(echo "c3Bpbm5lcj0oICd8JyAnLycgJy0nICdcJyApOwoKY291bnQoKXsKICBzcGluICYKI
 # Dependencies Installation
 center "* Dependencies installation..."
 # Skip mirror selection if sources.list is already configured (for CI)
-if ! grep -q "packages.termux.dev" /data/data/com.termux/files/usr/etc/apt/sources.list 2>/dev/null; then
+if ! grep -q "gnlug.org" /data/data/com.termux/files/usr/etc/apt/sources.list 2>/dev/null; then
   pkg update -y
 else
   apt update -y
@@ -45,7 +45,7 @@ DEBIAN_FRONTEND=noninteractive pkg upgrade -y -o Dpkg::Options::="--force-confne
 pkg install -y binutils python autoconf bison clang coreutils curl findutils apr apr-util postgresql openssl readline libffi libgmp libpcap libsqlite libgrpc libtool libxml2 libxslt ncurses make ncurses-utils ncurses git wget unzip zip tar termux-tools termux-elf-cleaner pkg-config git ruby -o Dpkg::Options::="--force-confnew"
 python3 -m pip install requests
 
-# Fix ruby BigDecimal 
+# Fix ruby BigDecimal
 #center "* Fix ruby BigDecimal"
 #source <(curl -sL https://github.com/termux/termux-packages/files/2912002/fix-ruby-bigdecimal.sh.txt)
 
@@ -67,9 +67,9 @@ center "* Installation..."
 cd ${PREFIX}/opt/metasploit-framework
 gem install bundler
 NOKOGIRI_VERSION=$(cat Gemfile.lock | grep -i nokogiri | sed 's/nokogiri [\(\)]/(/g' | cut -d ' ' -f 5 | grep -oP "(.).[[:digit:]][\w+]?[.].")
-# by overriding cflags nokogiri will install or you can simply declare a void function 
+# by overriding cflags nokogiri will install or you can simply declare a void function
 #  you might have seen this error while installing nokogiri `xmlSetStructuredErrorFunc((void *)rb_error_list, Nokogiri_error_array_pusher);`
-#  solution : void xmlSetStructuredErrorFunc(void *rb_error_list, void *Nokogiri_error_array_pusher); you can set any parameter name 
+#  solution : void xmlSetStructuredErrorFunc(void *rb_error_list, void *Nokogiri_error_array_pusher); you can set any parameter name
 #  for sake of simplicity tweaking cflags is better than declaring a void function for every c file
 
 gem install nokogiri -v $NOKOGIRI_VERSION -- --with-cflags="-Wno-implicit-function-declaration -Wno-deprecated-declarations -Wno-incompatible-function-pointer-types" --use-system-libraries

--- a/metasploit.sh
+++ b/metasploit.sh
@@ -77,7 +77,11 @@ NOKOGIRI_VERSION=$(cat Gemfile.lock | grep -i nokogiri | sed 's/nokogiri [\(\)]/
 #  for sake of simplicity tweaking cflags is better than declaring a void function for every c file
 
 gem install nokogiri -v $NOKOGIRI_VERSION -- --with-cflags="-Wno-implicit-function-declaration -Wno-deprecated-declarations -Wno-incompatible-function-pointer-types" --use-system-libraries
-bundle install
+
+# Fix bundler error
+BUNDLER_VERSION="$(sed -n '/BUNDLED WITH/{n;s/^ *//;p}' Gemfile.lock)"
+gem install bundler -v "${BUNDLER_VERSION}"
+
 gem install actionpack
 bundle update activesupport
 bundle update --bundler

--- a/metasploit.sh
+++ b/metasploit.sh
@@ -45,6 +45,10 @@ DEBIAN_FRONTEND=noninteractive pkg upgrade -y -o Dpkg::Options::="--force-confne
 pkg install -y binutils python autoconf bison clang coreutils curl findutils apr apr-util postgresql openssl readline libffi libgmp libpcap libsqlite libgrpc libtool libxml2 libxslt ncurses make ncurses-utils ncurses git wget unzip zip tar termux-tools termux-elf-cleaner pkg-config git ruby -o Dpkg::Options::="--force-confnew"
 python3 -m pip install requests
 
+# Fix Ruby 3.4.0 & Nokogiri by qrt2
+# https://github.com/qrt2/msf-termux-ruby34
+find $PREFIX/include -name rbasic.h -exec sed -i 's/const VALUE klass;/VALUE klass;/g' {} +
+
 # Fix ruby BigDecimal
 #center "* Fix ruby BigDecimal"
 #source <(curl -sL https://github.com/termux/termux-packages/files/2912002/fix-ruby-bigdecimal.sh.txt)

--- a/metasploit.sh
+++ b/metasploit.sh
@@ -70,7 +70,7 @@ git clone https://github.com/rapid7/metasploit-framework.git --depth=1 ${PREFIX}
 center "* Installation..."
 cd ${PREFIX}/opt/metasploit-framework
 gem install bundler
-NOKOGIRI_VERSION=$(cat Gemfile.lock | grep -i nokogiri | sed 's/nokogiri [\(\)]/(/g' | cut -d ' ' -f 5 | grep -oP "(.).[[:digit:]][\w+]?[.].")
+NOKOGIRI_VERSION=$(cat Gemfile.lock | grep -i nokogiri | sed 's/nokogiri [\(\)]/(/g' | cut -d ' ' -f 5 | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?')
 # by overriding cflags nokogiri will install or you can simply declare a void function
 #  you might have seen this error while installing nokogiri `xmlSetStructuredErrorFunc((void *)rb_error_list, Nokogiri_error_array_pusher);`
 #  solution : void xmlSetStructuredErrorFunc(void *rb_error_list, void *Nokogiri_error_array_pusher); you can set any parameter name


### PR DESCRIPTION
Hard forking for now since the repo since not maintained. See <https://github.com/gushmazuko/metasploit_in_termux/issues/304#issuecomment-4586429141>.

---

## Fixes

- Fix Ruby 3.4.0 & Nokogiri by [qrt2](https://github.com/qrt2/msf-termux-ruby34).
- Change `grep` to without `-P` flag since it may not be available.
- Fix Bundler error by install the version specified in lock file with `gem install` directly.
- Fix SQLite3 error by clone the [repo](https://github.com/sparklemotion/sqlite3-ruby/tree/main), compile, and `gem install` directly.
- `termux-fix-shebang` the binaries.
- Go to `~` at start.
- ~Change source to <https://gnlug.org/pub/termux> since <https://packages.termux.dev> is unreachable for now.~
## Results
- The GitHub action can now run without error.
- Install successfully on termux proot-distro.
- I still can't install successfully on Termux (not proot) on my local machine. I suspect the reason is that I've messed up some directories in `$PREFIX`. I'll test it with a fresh install of Termux when I have time. I can't do it now since my work depends on tools that I've installed in it and I currently don't have time to install them back in a fresh install as they are about 40 GB. I appreciate it if anyone can test whether it work on a real phone.
